### PR TITLE
Simplifies module name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,6 @@ data ibm_resource_group resource_group {
 }
 
 locals {
-  name_prefix = var.name_prefix != "" ? var.name_prefix : var.resource_group_name
   name        = "activity-tracker-${var.resource_location}"
   service     = "logdnaat"
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource null_resource print_names {
   }
 }
 
-data "ibm_resource_group" "tools_resource_group" {
+data ibm_resource_group resource_group {
   depends_on = [null_resource.print_names]
 
   name = var.resource_group_name
@@ -13,7 +13,7 @@ data "ibm_resource_group" "tools_resource_group" {
 
 locals {
   name_prefix = var.name_prefix != "" ? var.name_prefix : var.resource_group_name
-  name        = "${replace(local.name_prefix, "/[^a-zA-Z0-9_\\-\\.]/", "")}-${var.label}"
+  name        = "activity-tracker-${var.resource_location}"
   service     = "logdnaat"
 }
 
@@ -23,7 +23,7 @@ resource ibm_resource_instance at_instance {
   service           = local.service
   plan              = var.plan
   location          = var.resource_location
-  resource_group_id = data.ibm_resource_group.tools_resource_group.id
+  resource_group_id = data.ibm_resource_group.resource_group.id
   tags              = var.tags
 
   timeouts {
@@ -37,7 +37,7 @@ data ibm_resource_instance instance {
   depends_on = [ibm_resource_instance.at_instance]
 
   name              = local.name
-  resource_group_id = data.ibm_resource_group.tools_resource_group.id
+  resource_group_id = data.ibm_resource_group.resource_group.id
   location          = var.resource_location
   service           = local.service
 }

--- a/module.yaml
+++ b/module.yaml
@@ -21,6 +21,3 @@ versions:
     - name: resource_location
       scope: global
       alias: region
-    - name: name_prefix
-      scope: global
-

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,6 +33,6 @@ output "service" {
 
 output "label" {
   description = "The label for the instance"
-  value       = var.label
+  value       = var.resource_location
   depends_on = [data.ibm_resource_instance.instance]
 }

--- a/test/stages/stage2-activity-tracker.tf
+++ b/test/stages/stage2-activity-tracker.tf
@@ -2,6 +2,6 @@ module "dev_activity_tracker" {
   source = "./module"
 
   resource_group_name      = module.resource_group.name
-  resource_location        = var.region
+  resource_location        = "eu-gb"
   provision                = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,12 +14,6 @@ variable "tags" {
   default     = []
 }
 
-variable "name_prefix" {
-  type        = string
-  description = "The prefix name for the service. If not provided it will default to the resource group name"
-  default     = ""
-}
-
 variable "plan" {
   type        = string
   description = "The type of plan the service instance should run under (lite, 7-day, 14-day, or 30-day)"
@@ -30,10 +24,4 @@ variable "provision" {
   type        = bool
   description = "Flag indicating that the instance should be provisioned"
   default     = false
-}
-
-variable "label" {
-  type        = string
-  description = "Label used to build the resource name if one is not provided."
-  default     = "activity-tracker"
 }


### PR DESCRIPTION
- Uses a standard name based on the region deployed since only one instance per account per region can be provisioned

Fixes #12

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>