### PR TITLE
Updates cli submodule to pin version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,8 @@ data ibm_resource_group resource_group {
 }
 
 module "clis" {
-  source = "github.com/cloud-native-toolkit/terraform-util-clis.git"
+  source = "cloud-native-toolkit/clis/util"
+  version = "1.9.5"
 }
 
 resource "random_uuid" "tag" {


### PR DESCRIPTION
- Pins cli submodule version to 1.9.5 and uses `cloud-native-toolkit/clis/util` for registry id

Closes #39

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>